### PR TITLE
Fix typing in ThemeProvider

### DIFF
--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -132,14 +132,14 @@ const ThemeContext = createContext<ThemeContextType>({
 const useTheme = () => useContext(ThemeContext);
 
 // Theme provider component
-const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }: { children: ReactNode }) => {
   const colorScheme = useColorScheme();
   const [isDark, setIsDark] = useState(colorScheme === 'dark');
   
   const theme = isDark ? darkTheme : lightTheme;
   
   const toggleTheme = useCallback(() => {
-    setIsDark(prev => !prev);
+    setIsDark((prev: boolean) => !prev);
   }, []);
 
   const contextValue = React.useMemo(() => ({


### PR DESCRIPTION
## Summary
- explicitly type ThemeProvider props and state update callback

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'expo/tsconfig.base', missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842b48798288330bf8473654b20c066