### PR TITLE
Add Jest config and tests for style helpers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -35,7 +36,10 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2"
   },
   "private": true
 }

--- a/src/theme/styles.test.ts
+++ b/src/theme/styles.test.ts
@@ -1,0 +1,42 @@
+const mockDimensionsGet = jest.fn();
+let platform = { OS: 'ios', isPad: false, isTV: false, select: (obj: any) => obj['ios'] };
+
+jest.mock('react-native', () => ({
+  Platform: platform,
+  Dimensions: { get: mockDimensionsGet },
+  StyleSheet: { create: (s: any) => s },
+}));
+
+import { isIphoneX, getStatusBarHeight } from './styles';
+
+describe('style helpers', () => {
+  beforeEach(() => {
+    mockDimensionsGet.mockReset();
+    platform.OS = 'ios';
+    platform.isPad = false;
+    platform.isTV = false;
+    platform.select = (obj: any) => obj[platform.OS] ?? obj.default;
+  });
+
+  test('isIphoneX detects iPhone X dimensions', () => {
+    mockDimensionsGet.mockReturnValue({ width: 375, height: 812 });
+    expect(isIphoneX()).toBe(true);
+  });
+
+  test('isIphoneX returns false for non matching device', () => {
+    mockDimensionsGet.mockReturnValue({ width: 375, height: 667 });
+    expect(isIphoneX()).toBe(false);
+  });
+
+  test('getStatusBarHeight returns iPhone X heights', () => {
+    mockDimensionsGet.mockReturnValue({ width: 375, height: 812 });
+    expect(getStatusBarHeight()).toBe(30);
+    expect(getStatusBarHeight(true)).toBe(44);
+  });
+
+  test('getStatusBarHeight returns defaults on android', () => {
+    platform.OS = 'android';
+    mockDimensionsGet.mockReturnValue({ width: 375, height: 812 });
+    expect(getStatusBarHeight()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest devDeps and script in package.json
- add Jest configuration
- add unit tests for `isIphoneX` and `getStatusBarHeight`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cd8f2df88330bf25abf07982e180