### PR TITLE
fix: correct profile navigation route

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -70,9 +70,9 @@ const HomeScreen = () => {
         </TouchableOpacity>
       </View>
 
-      <TouchableOpacity 
+      <TouchableOpacity
         style={styles.profileButton}
-        onPress={() => navigation.navigate('Profile')}
+        onPress={() => navigation.navigate('ProfileTab')}
       >
         <Text style={styles.profileButtonText}>Profile</Text>
       </TouchableOpacity>


### PR DESCRIPTION
## Summary
- link profile button to `ProfileTab` instead of `Profile`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6842cd86b428833080742ad3ff7595ba