### PR TITLE
Add expo-clipboard dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Getting started
 
 - npm install
+- npx expo install expo-clipboard # required for clipboard functionality
 - npm run ios
 - npx expo start --ios
 - npm run android (or npx expo start --android)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "expo-secure-store": "~14.2.3",
     "expo-status-bar": "~2.2.3",
     "expo-web-browser": "~14.1.6",
+    "expo-clipboard": "~4.2.2",
     "react": "19.0.0",
     "react-native": "^0.79.3",
     "react-native-gesture-handler": "~2.24.0",


### PR DESCRIPTION
## Summary
- add expo-clipboard to dependencies
- document expo-clipboard install step in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f28f8b24833081ad4081b2435f45